### PR TITLE
fix: remove stat providers: vercel.daephx no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,9 @@ Yo! My name's **Daemon**, I build software.
   <div align=center>
   <a href="#"><img height="192px" src="https://github-readme-streak-stats.herokuapp.com/?user=daephx&theme=tokyonight&hide_border=true&background=00000000&ring=5CC7E2&dates=5CC7E2"/></a>
   <a href="#"><img height="192px" src="https://github-profile-trophy.vercel.app/?username=daephx&row=2&column=3&margin-w=15&theme=discord&no-bg=true&no-frame=true"/></a>
-  </div>
-
-  <div align=center>
-  <a href="#"><img height="132px" src="https://github-readme-stats.daephx.vercel.app/api/?username=daephx&hide_title=true&show_icons=true&hide_border=true&line_height=21&bg_color=00000000&text_color=59c7e5&count_private=true&include_all_commits=true"/></a>
-  <a href="#"><img height="132px" src="https://github-readme-stats.daephx.vercel.app/api/top-langs/?username=daephx&exclude_repo=github-readme-stats,daephx.github.io,etckeeper-RPi,notebooks,gists,notes,vault,wiki,zettelkasten&hide=html,markdown&hide_title=true&layout=compact&langs_count=6&hide_border=true&bg_color=00000000&text_color=59c7e5"/></a>
-  <br>
-  </div>
-
   <a href="#"><img src="https://activity-graph.herokuapp.com/graph?username=daephx&theme=react-dark&bg_color=00000000&hide_border=true&area=true&custom_title=%20"/></a>
+  </div>
+
   <hr/>
 
 </details>


### PR DESCRIPTION
No provider is available for now...

Deployed fork for language and commit statistics removed in favor of
another provider. New provider not functional and vercel preemptively
nuked.